### PR TITLE
add Flush to Writer interface

### DIFF
--- a/database.go
+++ b/database.go
@@ -149,7 +149,7 @@ func (db *BadgerDB) Del(key []byte) error {
 
 // Flush commits pending writes to disk
 func (db *BadgerDB) Flush() error {
-	return db.Flush()
+	return db.db.Sync()
 }
 
 // Close closes a DB

--- a/database.go
+++ b/database.go
@@ -147,6 +147,11 @@ func (db *BadgerDB) Del(key []byte) error {
 	})
 }
 
+// Flush commits pending writes to disk
+func (db *BadgerDB) Flush() error {
+	return db.Flush()
+}
+
 // Close closes a DB
 func (db *BadgerDB) Close() error {
 	db.lock.Lock()
@@ -242,8 +247,8 @@ func (b *batchWriter) Put(key, value []byte) error {
 	return nil
 }
 
-// Write performs batched writes
-func (b *batchWriter) Write() error {
+// Flush commits pending writes to disk
+func (b *batchWriter) Flush() error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	wb := b.db.db.NewWriteBatch()

--- a/database_test.go
+++ b/database_test.go
@@ -144,9 +144,9 @@ func testBatchPut(db Database, t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to add key-value to batch mapping  %q", err)
 		}
-		err = b.Write()
+		err = b.Flush()
 		if err != nil {
-			t.Fatalf("failed to write batch %q", err)
+			t.Fatalf("failed to flush batch %q", err)
 		}
 		size := b.ValueSize()
 		if size == 0 {
@@ -178,9 +178,9 @@ func testIteratorSetup(db Database, t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to add key-value to batch mapping  %q", err)
 		}
-		err = b.Write()
+		err = b.Flush()
 		if err != nil {
-			t.Fatalf("failed to write batch %q", err)
+			t.Fatalf("failed to flush batch %q", err)
 		}
 	}
 }

--- a/interface.go
+++ b/interface.go
@@ -34,7 +34,6 @@ type Batch interface {
 	Writer
 
 	ValueSize() int
-	Write() error
 	Reset()
 }
 
@@ -57,4 +56,5 @@ type Reader interface {
 type Writer interface {
 	Put(key []byte, value []byte) error
 	Del(key []byte) error
+	Flush() error
 }

--- a/memoryDB.go
+++ b/memoryDB.go
@@ -106,3 +106,8 @@ func (db *MemDatabase) NewIterator() Iterator {
 func (db *MemDatabase) Path() string {
 	return fmt.Sprintf("&memDB=%p memDB=%v\n", db.db, db.db)
 }
+
+// Flush ...
+func (db *MemDatabase) Flush() error {
+	return nil
+}

--- a/table.go
+++ b/table.go
@@ -54,6 +54,11 @@ func (dt *table) Del(key []byte) error {
 	return dt.db.Del(append([]byte(dt.prefix), key...))
 }
 
+// Flush commits pending writes to disk
+func (dt *table) Flush() error {
+	return dt.db.Flush()
+}
+
 // Close closes table db
 func (dt *table) Close() error {
 	return dt.db.Close()
@@ -84,9 +89,9 @@ func (tb *tableBatch) Put(key, value []byte) error {
 	return tb.batch.Put(append([]byte(tb.prefix), key...), value)
 }
 
-// Write performs batched writes with the provided prefix
-func (tb *tableBatch) Write() error {
-	return tb.batch.Write()
+// Flush performs batched writes with the provided prefix
+func (tb *tableBatch) Flush() error {
+	return tb.batch.Flush()
 }
 
 // ValueSize returns the amount of data in the batch accounting for the given prefix

--- a/table_test.go
+++ b/table_test.go
@@ -125,9 +125,9 @@ func testBatchTablePutWithPrefix(db Database, t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to add key-value to batch mapping  %q", err)
 		}
-		err = b.Write()
+		err = b.Flush()
 		if err != nil {
-			t.Fatalf("failed to write batch %q", err)
+			t.Fatalf("failed to flush batch %q", err)
 		}
 		size := b.ValueSize()
 		if size == 0 {


### PR DESCRIPTION
add Flush to Writer interface, implement `Flush` for `BadgerDB`, `table`, `tableBatch`

closes https://github.com/ChainSafe/gossamer/issues/758