### PR TITLE
 fix iterator.Next

### DIFF
--- a/database.go
+++ b/database.go
@@ -198,6 +198,9 @@ func (i *BadgerIterator) Next() bool {
 		i.iter.Rewind()
 		i.init = true
 	}
+	if !i.iter.Valid() {
+		return false
+	}
 	i.iter.Next()
 	return i.iter.Valid()
 }


### PR DESCRIPTION
previously would panic if there was an empty db and `db.NewIterator().Next()` was called