### PR TITLE
update to create in memory db without creating directory

### DIFF
--- a/database.go
+++ b/database.go
@@ -18,12 +18,12 @@ package chaindb
 
 import (
 	"context"
-	"github.com/dgraph-io/badger/v2/options"
 	"os"
 	"sync"
 
 	log "github.com/ChainSafe/log15"
 	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 )
 
 // BadgerDB contains directory path to data and db instance

--- a/database.go
+++ b/database.go
@@ -50,7 +50,7 @@ func NewBadgerDB(cfg *Config) (*BadgerDB, error) {
 	if cfg.InMemory {
 		opts = badger.DefaultOptions("").WithInMemory(true)
 	} else {
-		opts := badger.DefaultOptions(cfg.DataDir)
+		opts = badger.DefaultOptions(cfg.DataDir)
 		opts.ValueDir = cfg.DataDir
 		opts.Logger = nil
 		opts.WithSyncWrites(false)


### PR DESCRIPTION
This PR updated function `NewBadgerDB` so that when cfg.InMemory is true it uses only badger.DefaultOptions("").WithInMemory(true) so that no data directory is created.  