### PR TITLE
fix: use default badger options

### DIFF
--- a/database.go
+++ b/database.go
@@ -56,9 +56,6 @@ func NewBadgerDB(cfg *Config) (*BadgerDB, error) {
 		opts = badger.DefaultOptions(cfg.DataDir)
 		opts.ValueDir = cfg.DataDir
 		opts.Logger = nil
-		opts.WithSyncWrites(false)
-		opts.WithNumCompactors(20)
-		// opts.WithBlockCacheSize(1 << 16) // TODO: add caching
 
 		if cfg.Compress {
 			opts.WithCompression(options.Snappy)


### PR DESCRIPTION
## Description
Gossamer fails while syncing with this stranger badger DB error, so removing the custom options `WithSyncWrites(false)` and `WithNumCompactors(20)` the given error was not happening while syncing

![image](https://github.com/ChainSafe/chaindb/assets/17255488/48a0db1c-66b7-4cc9-9c27-643f941e0080)
